### PR TITLE
Add calibration pattern detection APIs

### DIFF
--- a/fds.py
+++ b/fds.py
@@ -119,8 +119,7 @@ def detect_pattern(req: PatternDetectReq):
         squares_y = int(params.get("squares_y", 7))
         square_length = float(params.get("square_length", 1.0))
         marker_length = float(params.get("marker_length", 0.5))
-        board = cv2.aruco.CharucoBoard_create(
-            squares_x, squares_y, square_length, marker_length, dictionary)
+        board = cv2.aruco.CharucoBoard((squares_x, squares_y), square_length, marker_length, dictionary)
         corners, ids, _ = cv2.aruco.detectMarkers(gray, dictionary)
         if ids is not None and len(ids) > 0:
             cv2.aruco.drawDetectedMarkers(overlay, corners, ids)

--- a/test/test_patterns.py
+++ b/test/test_patterns.py
@@ -1,0 +1,60 @@
+import numpy as np
+import cv2
+from unittest.mock import patch, MagicMock
+from fastapi.testclient import TestClient
+
+from fds import app
+
+client = TestClient(app)
+
+@patch('fds.cv2.aruco.interpolateCornersCharuco')
+@patch('fds.cv2.aruco.detectMarkers')
+@patch('fds.requests.get')
+def test_detect_pattern_charuco(mock_get, mock_detect, mock_interp, sample_image):
+    _, img_encoded = cv2.imencode('.png', sample_image)
+    mock_resp = MagicMock(); mock_resp.status_code = 200; mock_resp.content = img_encoded.tobytes()
+    mock_get.return_value = mock_resp
+    mock_detect.return_value = ([np.zeros((1,4,2), dtype=np.float32)], np.array([[1]]), None)
+    mock_interp.return_value = (True, np.array([[[0.5,0.5]]], dtype=np.float32), np.array([1]))
+    response = client.post('/detect_pattern', json={'image_id':'id1','pattern':'charuco','params':{}})
+    assert response.status_code == 200
+    data = response.json()
+    assert data['count'] == 1
+    assert data['points'][0]['id'] == 1
+
+@patch('fds.cv2.findCirclesGrid')
+@patch('fds.requests.get')
+def test_detect_pattern_circle_grid(mock_get, mock_find, sample_image):
+    _, img_encoded = cv2.imencode('.png', sample_image)
+    mock_resp = MagicMock(); mock_resp.status_code = 200; mock_resp.content = img_encoded.tobytes()
+    mock_get.return_value = mock_resp
+    mock_find.return_value = (True, np.array([[[1.0,2.0]]], dtype=np.float32))
+    response = client.post('/detect_pattern', json={'image_id':'id2','pattern':'circle_grid','params':{'rows':1,'cols':1}})
+    assert response.status_code == 200
+    data = response.json()
+    assert data['count'] == 1
+
+@patch('fds.cv2.findChessboardCorners')
+@patch('fds.requests.get')
+def test_detect_pattern_chessboard(mock_get, mock_find, sample_image):
+    _, img_encoded = cv2.imencode('.png', sample_image)
+    mock_resp = MagicMock(); mock_resp.status_code = 200; mock_resp.content = img_encoded.tobytes()
+    mock_get.return_value = mock_resp
+    mock_find.return_value = (True, np.array([[[1.0,2.0]]], dtype=np.float32))
+    response = client.post('/detect_pattern', json={'image_id':'id3','pattern':'chessboard','params':{'rows':1,'cols':1}})
+    assert response.status_code == 200
+    data = response.json()
+    assert data['count'] == 1
+
+@patch('fds.cv2.aruco.detectMarkers')
+@patch('fds.requests.get')
+def test_detect_pattern_apriltag(mock_get, mock_detect, sample_image):
+    _, img_encoded = cv2.imencode('.png', sample_image)
+    mock_resp = MagicMock(); mock_resp.status_code = 200; mock_resp.content = img_encoded.tobytes()
+    mock_get.return_value = mock_resp
+    mock_detect.return_value = ([np.zeros((1,4,2), dtype=np.float32)], np.array([[3]]), None)
+    response = client.post('/detect_pattern', json={'image_id':'id4','pattern':'apriltag','params':{}})
+    assert response.status_code == 200
+    data = response.json()
+    assert data['count'] == 1
+    assert data['points'][0]['id'] == 3


### PR DESCRIPTION
## Summary
- support ChArUco, circle grid, chessboard and AprilTag pattern detection
- expose `/detect_pattern` and `/patterns` endpoints
- document new pattern APIs and add unit tests

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bae9e3f05c833293c4e4077481f477